### PR TITLE
Skip updates for already updated disabled mods

### DIFF
--- a/KKManager.Core/Data/Plugins/PluginInfo.cs
+++ b/KKManager.Core/Data/Plugins/PluginInfo.cs
@@ -31,26 +31,17 @@ namespace KKManager.Data.Plugins
 
         public override void SetEnabled(bool value)
         {
-            if (Location.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase))
+            if (Enabled != value)
             {
-                if (!value)
-                {
-                    var newName = Location.FullName.Substring(0, Location.FullName.Length - 1) + '_';
-                    Location.MoveTo(newName);
-                }
+                Location.MoveTo(EnabledLocation(Location, value).FullName);
             }
-            else if (Location.Extension.Equals(".dl_", StringComparison.OrdinalIgnoreCase))
-            {
-                if (value)
-                {
-                    var newName = Location.FullName.Substring(0, Location.FullName.Length - 1) + 'l';
-                    Location.MoveTo(newName);
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException("Plugin has invalid extension: " + Location.Extension);
-            }
+        }
+
+        public static FileInfo EnabledLocation(FileInfo location, bool enable = true)
+        {
+            var ext = location.Extension.ToCharArray();
+            ext[3] = enable ? 'l' : '_';
+            return new FileInfo(location.FullName.Substring(0, location.FullName.Length - ext.Length) + new string(ext));
         }
     }
 }

--- a/KKManager.Core/Data/Zipmods/SideloaderModInfo.cs
+++ b/KKManager.Core/Data/Zipmods/SideloaderModInfo.cs
@@ -12,6 +12,10 @@ namespace KKManager.Data.Zipmods
             string author, string description, string website, IReadOnlyList<Image> images, IReadOnlyList<string> contents)
             : base(location, guid, name, version)
         {
+            var extension = location.Extension;
+            if (!SideloaderModLoader.IsValidZipmodExtension(extension))
+                throw new InvalidOperationException("Zipmod has invalid extension: " + Location.Extension);
+
             Author = author;
             Description = description;
             Website = website;
@@ -48,32 +52,17 @@ namespace KKManager.Data.Zipmods
 
         public override void SetEnabled(bool value)
         {
-            if (Location.Extension.StartsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            if (Enabled != value)
             {
-                if (!value)
-                {
-                    var newExt = Location.Extension.ToCharArray();
-                    newExt[3] = '_';
+                Location.MoveTo(EnabledLocation(Location, value).FullName);
+            }
+        }
 
-                    var newName = Location.FullName.Substring(0, Location.FullName.Length - newExt.Length) + new string(newExt);
-                    Location.MoveTo(newName);
-                }
-            }
-            else if (Location.Extension.StartsWith(".zi_", StringComparison.OrdinalIgnoreCase))
-            {
-                if (value)
-                {
-                    var newExt = Location.Extension.ToCharArray();
-                    newExt[3] = 'p';
-
-                    var newName = Location.FullName.Substring(0, Location.FullName.Length - newExt.Length) + new string(newExt);
-                    Location.MoveTo(newName);
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException("Zipmod has invalid extension: " + Location.Extension);
-            }
+        public static FileInfo EnabledLocation(FileInfo location, bool enable = true)
+        {
+            var ext = location.Extension.ToCharArray();
+            ext[3] = enable ? 'p' : '_';
+            return new FileInfo(location.FullName.Substring(0, location.FullName.Length - ext.Length) + new string(ext));
         }
     }
 }


### PR DESCRIPTION
Disabled mods and plugins all show as needing updates because the filenames all differ (zip vs zi_). Check against enabled file names when filtering up-to-date mods to prevent this. Updates are enabled even if the old version was disabled.

Includes slight rework of SetEnabled to reuse more code.