### PR TITLE
Add support for AppData log files and update menu entry

### DIFF
--- a/src/KKManager.Core/Functions/DebugInfo.cs
+++ b/src/KKManager.Core/Functions/DebugInfo.cs
@@ -11,7 +11,7 @@ namespace KKManager.Functions
         public static void GenerateDebugInfo(string atPath)
         {
             var epoch = new DateTimeOffset(DateTime.Now).ToUnixTimeSeconds().ToString();
-            var tempDebugDir = Directory.CreateDirectory(Path.Combine(atPath, $"DebugInfoTemp {epoch}"));           
+            var tempDebugDir = Directory.CreateDirectory(Path.Combine(atPath, $"DebugInfoTemp {epoch}"));
 
             try
             {
@@ -21,10 +21,10 @@ namespace KKManager.Functions
                 ZipPluginsAndConfig(Path.Combine(tempDebugDir.FullName, "Bepin.zip"));
 
                 GetLogs(tempDebugDir);
-                
+
                 ZipFile.CreateFromDirectory(tempDebugDir.FullName, Path.Combine(atPath,
                     $"{InstallDirectoryHelper.GameType.GetFancyGameName()} Debug Info {epoch}.zip"));
-            }           
+            }
             finally
             {
                 tempDebugDir.Delete(true);
@@ -81,8 +81,8 @@ namespace KKManager.Functions
             var nameLength = 0;
             foreach (var file in files)
             {
-                if (file.Name.Length > nameLength) 
-                { 
+                if (file.Name.Length > nameLength)
+                {
                     nameLength = file.Name.Length;  //This doesn't handle multibyte Unicode characters correctly
                 }
             }
@@ -153,26 +153,10 @@ namespace KKManager.Functions
 
         private static void GetLogs(DirectoryInfo debugDirInfo)
         {
-            var logOutputFiles = InstallDirectoryHelper.GameDirectory.EnumerateFiles("LogOutput.log*", SearchOption.AllDirectories).ToArray();
-            var outputLogFiles = InstallDirectoryHelper.GameDirectory.EnumerateFiles("output_log.txt", SearchOption.AllDirectories).ToArray();
-
-            if (outputLogFiles.Length == 0)
-            {
-                //We are probably on one of the games that logs to AppData/LocalLow, and the user hasn't configured Doorstop to redirect the logs.
-                //For now just log that this happens instead of trying to traverse the AppData folder (since we'd have to determine the subfolder name in AppData anyway)
-                Console.WriteLine("Could not locate output_log.txt! Check if redirect_output_log is set to true in doorstop_config.ini");
-            }
+            var logOutputFiles = InstallDirectoryHelper.FindLogFiles(true);
 
             foreach (var logFile in logOutputFiles)
-            {
                 logFile.CopyTo(Path.Combine(debugDirInfo.FullName, logFile.Name), true);
-            }
-
-            foreach (var outputFile in outputLogFiles)
-            {
-                var uniqueName = $"{outputFile.Directory.Name} {outputFile.Name}"; //There may be be multiple output_logs so we have to differentiate them
-                outputFile.CopyTo(Path.Combine(debugDirInfo.FullName, uniqueName), true);
-            }
         }
     }
 }

--- a/src/KKManager.Core/Functions/InstallDirectoryHelper.cs
+++ b/src/KKManager.Core/Functions/InstallDirectoryHelper.cs
@@ -250,9 +250,12 @@ namespace KKManager.Functions
             {
                 var localLow = PathTools.GetAppDataLocalLowPath();
                 var appdataLogPath = Path.Combine(localLow, relativePath);
-                // It can be either Player.log or output_log.txt depending on Unity version
-                candidates.AddRange(Directory.GetFiles(appdataLogPath, "Player.log", SearchOption.AllDirectories).Select(x => new FileInfo(x)));
-                candidates.AddRange(Directory.GetFiles(appdataLogPath, "output_log.txt", SearchOption.AllDirectories).Select(x => new FileInfo(x)));
+                if (Directory.Exists(appdataLogPath))
+                {
+                    // It can be either Player.log or output_log.txt depending on Unity version
+                    candidates.AddRange(Directory.GetFiles(appdataLogPath, "Player.log", SearchOption.AllDirectories).Select(x => new FileInfo(x)));
+                    candidates.AddRange(Directory.GetFiles(appdataLogPath, "output_log.txt", SearchOption.AllDirectories).Select(x => new FileInfo(x)));
+                }
             }
 
             if (filter)

--- a/src/KKManager.Core/Functions/InstallDirectoryHelper.cs
+++ b/src/KKManager.Core/Functions/InstallDirectoryHelper.cs
@@ -200,11 +200,11 @@ namespace KKManager.Functions
             {
                 var candidates = FindLogFiles(true);
 
-                var latestLog = candidates.FirstOrDefault();
-                if (latestLog == null)
+                if (!candidates.Any())
                     throw new FileNotFoundException("No log files were found");
 
-                Process.Start(latestLog.FullName);
+                foreach (var candidate in candidates.Take(3))
+                    Process.Start(candidate.FullName);
             }
             catch (Exception exception)
             {

--- a/src/KKManager.Core/Functions/InstallDirectoryHelper.cs
+++ b/src/KKManager.Core/Functions/InstallDirectoryHelper.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using KKManager.Util;
 
 namespace KKManager.Functions
 {
@@ -197,38 +198,74 @@ namespace KKManager.Functions
         {
             try
             {
-                bool TryOpen(string path)
-                {
-                    if (path == null) return false;
-                    try
-                    {
-                        Process.Start(path);
-                        return true;
-                    }
-                    catch
-                    {
-                        return false;
-                    }
-                }
+                var candidates = FindLogFiles(true);
 
-                var rootDir = GameDirectory.FullName;
-                var candidates = new List<string>();
+                var latestLog = candidates.FirstOrDefault();
+                if (latestLog == null)
+                    throw new FileNotFoundException("No log files were found");
 
-                // BepInEx 5.x log file, can be "LogOutput.log.1" or higher if multiple game instances run.
-                candidates.AddRange(Directory.GetFiles(rootDir, "LogOutput.log*", SearchOption.AllDirectories));
-                // Unity built-in log file, by default inside _Data dir, disabled, or somewhere in appdata. Can be moved to game root by BepInEx preloader if configured.
-                candidates.AddRange(Directory.GetFiles(rootDir, "output_log.txt", SearchOption.AllDirectories));
-
-                var latestLog = candidates.Where(File.Exists).OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault();
-                if (TryOpen(latestLog)) return;
-
-                throw new FileNotFoundException("No log files were found");
+                Process.Start(latestLog.FullName);
             }
             catch (Exception exception)
             {
                 Console.WriteLine(exception);
                 MessageBox.Show(string.Format(Resources.OpenGameLogFailedMessage, exception.Message), Resources.OpenGameLogMessageTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private static readonly Dictionary<GameType, string> _AppdataRelativePaths = new Dictionary<GameType, string>
+        {
+            { GameType.Koikatsu , @"illusion__Koikatu\Koikatu"},
+            { GameType.KoikatsuSteam , @"illusion__Koikatsu\Koikatsu Party"},
+            { GameType.KoikatsuSunshine , @"illusion__KoikatsuSunshine\KoikatsuSunshine"},
+            { GameType.EmotionCreators , @"illusion__EmotionCreators\EmotionCreators"},
+
+            { GameType.AiShoujo ,@"illusion__AI-Syoujyo\AI-Syoujyo"},
+            { GameType.AiShoujoSteam ,@"illusion__AI-Shoujo\AI-Shoujo"},
+            { GameType.HoneySelect2 , @"illusion__HoneySelect2\HoneySelect2"}, //TODO: illusion__HoneySelect2_Steam\HoneySelect2_Steam
+            
+            { GameType.RoomGirl, @"illusion__RoomGirl\RoomGirl" },
+            // VR_Kanojo ILLUSION\VR_Kanojo
+
+            { GameType.HoneyCome ,@"ILLGAMES\HoneyCome"},
+            { GameType.HoneyComeSteam ,@"ILLGAMES\HoneyComeccp"},
+            { GameType.SamabakeScramble , @"ILLGAMES\SamabakeScramble"},
+            { GameType.Aicomi, @"ILLGAMES\Aicomi" },
+        };
+
+        /// <summary>
+        /// Finds log files for the current game.
+        /// </summary>
+        /// <param name="filter">Whether to filter the log files to only include the latest ones. If true, results are ordered by last write time (descending).</param>
+        /// <returns>A list of log files for the current game.</returns>
+        public static List<FileInfo> FindLogFiles(bool filter)
+        {
+            var candidates = new List<FileInfo>();
+            // BepInEx 5.x log file, can be "LogOutput.log.1" or higher if multiple game instances run.
+            candidates.AddRange(GameDirectory.GetFiles("LogOutput.log*", SearchOption.AllDirectories));
+            // Unity built-in log file, by default inside _Data dir, disabled, or somewhere in appdata. Can be moved to game root by BepInEx preloader if configured.
+            candidates.AddRange(GameDirectory.GetFiles("output_log.txt", SearchOption.AllDirectories));
+            // Check for log files stored in AppData/LocalLow in case they were not redirected by preloader config
+            if (_AppdataRelativePaths.TryGetValue(GameType, out var relativePath))
+            {
+                var localLow = PathTools.GetAppDataLocalLowPath();
+                var appdataLogPath = Path.Combine(localLow, relativePath);
+                // It can be either Player.log or output_log.txt depending on Unity version
+                candidates.AddRange(Directory.GetFiles(appdataLogPath, "Player.log", SearchOption.AllDirectories).Select(x => new FileInfo(x)));
+                candidates.AddRange(Directory.GetFiles(appdataLogPath, "output_log.txt", SearchOption.AllDirectories).Select(x => new FileInfo(x)));
+            }
+
+            if (filter)
+            {
+                candidates = candidates
+                             // Only keep the latest log file for each name (e.g. in case output_log.txt is both in game root and in appdata)
+                             .GroupBy(x => x.Name).Select(z => z.OrderByDescending(x => x.LastWriteTimeUtc).ThenByDescending(x => x.CreationTimeUtc).First())
+                             // Order by last write time to have the most recent log on top (e.g. in case output_log.txt and LogOutput.log both exist)
+                             .OrderByDescending(x => x.LastWriteTimeUtc).ThenByDescending(x => x.CreationTimeUtc)
+                             .ToList();
+            }
+
+            return candidates;
         }
     }
 }

--- a/src/KKManager.Core/Util/PathTools.cs
+++ b/src/KKManager.Core/Util/PathTools.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace KKManager.Util
@@ -136,5 +137,31 @@ namespace KKManager.Util
             }
             return new string(a);
         }
+
+        public static string GetAppDataLocalLowPath()
+        {
+            Guid localLowId = new Guid("A520A1A4-1780-4FF6-BD18-167343C5AF16");
+            return GetKnownFolderPath(localLowId);
+        }
+
+        private static string GetKnownFolderPath(Guid knownFolderId)
+        {
+            IntPtr pszPath = IntPtr.Zero;
+            try
+            {
+                int hr = SHGetKnownFolderPath(knownFolderId, 0, IntPtr.Zero, out pszPath);
+                if (hr >= 0)
+                    return Marshal.PtrToStringAuto(pszPath);
+                throw Marshal.GetExceptionForHR(hr);
+            }
+            finally
+            {
+                if (pszPath != IntPtr.Zero)
+                    Marshal.FreeCoTaskMem(pszPath);
+            }
+        }
+
+        [DllImport("shell32.dll")]
+        private static extern int SHGetKnownFolderPath( [MarshalAs(UnmanagedType.LPStruct)] Guid rfid, uint dwFlags, IntPtr hToken, out IntPtr pszPath);
     }
 }

--- a/src/KKManager/Windows/MainWindow.Designer.cs
+++ b/src/KKManager/Windows/MainWindow.Designer.cs
@@ -70,10 +70,11 @@ namespace KKManager.Windows
             this.useSystemProxyServerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.p2PDownloaderSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.generateDebugInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.fixFileAndFolderPermissionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compressGameFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cleanUpDuplicateZipmodsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateDebugInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.developersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openModpackToolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -95,7 +96,6 @@ namespace KKManager.Windows
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabelStatus = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.menuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -366,6 +366,17 @@ namespace KKManager.Windows
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             resources.ApplyResources(this.toolsToolStripMenuItem, "toolsToolStripMenuItem");
             // 
+            // generateDebugInfoToolStripMenuItem
+            // 
+            this.generateDebugInfoToolStripMenuItem.Name = "generateDebugInfoToolStripMenuItem";
+            resources.ApplyResources(this.generateDebugInfoToolStripMenuItem, "generateDebugInfoToolStripMenuItem");
+            this.generateDebugInfoToolStripMenuItem.Click += new System.EventHandler(this.generateDebugInfoZip_Click);
+            // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            resources.ApplyResources(this.toolStripSeparator10, "toolStripSeparator10");
+            // 
             // fixFileAndFolderPermissionsToolStripMenuItem
             // 
             this.fixFileAndFolderPermissionsToolStripMenuItem.Name = "fixFileAndFolderPermissionsToolStripMenuItem";
@@ -383,12 +394,6 @@ namespace KKManager.Windows
             this.cleanUpDuplicateZipmodsToolStripMenuItem.Name = "cleanUpDuplicateZipmodsToolStripMenuItem";
             resources.ApplyResources(this.cleanUpDuplicateZipmodsToolStripMenuItem, "cleanUpDuplicateZipmodsToolStripMenuItem");
             this.cleanUpDuplicateZipmodsToolStripMenuItem.Click += new System.EventHandler(this.cleanUpDuplicateZipmodsToolStripMenuItem_Click);
-            // 
-            // generateDebugInfoToolStripMenuItem
-            // 
-            this.generateDebugInfoToolStripMenuItem.Name = "generateDebugInfoToolStripMenuItem";
-            resources.ApplyResources(this.generateDebugInfoToolStripMenuItem, "generateDebugInfoToolStripMenuItem");
-            this.generateDebugInfoToolStripMenuItem.Click += new System.EventHandler(this.generateDebugInfoZip_Click);
             // 
             // toolStripSeparator3
             // 
@@ -525,11 +530,6 @@ namespace KKManager.Windows
             this.toolTip1.InitialDelay = 200;
             this.toolTip1.ReshowDelay = 100;
             this.toolTip1.ShowAlways = true;
-            // 
-            // toolStripSeparator10
-            // 
-            this.toolStripSeparator10.Name = "toolStripSeparator10";
-            resources.ApplyResources(this.toolStripSeparator10, "toolStripSeparator10");
             // 
             // MainWindow
             // 

--- a/src/KKManager/Windows/MainWindow.resx
+++ b/src/KKManager/Windows/MainWindow.resx
@@ -367,7 +367,7 @@ For plugins, patchers and especially non-zipmod mods it's recommended to follow 
   </data>
   <data name="fixFileAndFolderPermissionsToolStripMenuItem.ToolTipText" xml:space="preserve">
     <value>This will attempt to fix any file or folder permission issues in the game directory.
-Make sure that no other applications are using anything inside the game directory before uisng, otherwise a PC restart might be required to be able to access some of the files again.</value>
+Make sure that no other applications are using anything inside the game directory before using, otherwise a PC restart might be required to be able to access some of the files again.</value>
   </data>
   <data name="compressGameFilesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>231, 22</value>

--- a/src/KKManager/Windows/MainWindow.resx
+++ b/src/KKManager/Windows/MainWindow.resx
@@ -121,154 +121,16 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="fileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 20</value>
-  </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;File</value>
-  </data>
-  <data name="viewToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="viewToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;View</value>
-  </data>
-  <data name="startTheGameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 20</value>
-  </data>
-  <data name="startTheGameToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Start</value>
-  </data>
-  <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 20</value>
-  </data>
-  <data name="openToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Open directory</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="installANewModToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="installANewModToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 20</value>
-  </data>
-  <data name="installANewModToolStripMenuItem.Text" xml:space="preserve">
-    <value>Install a new mod...</value>
-  </data>
-  <data name="installANewModToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>Attempt to install a plugin or a zipmod. 
-For plugins, patchers and especially non-zipmod mods it's recommended to follow the installation steps provided by the author instead.</value>
-  </data>
-  <data name="installANewModToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="updateSideloaderModpackToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 20</value>
-  </data>
-  <data name="updateSideloaderModpackToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Mod updater</value>
-  </data>
-  <data name="generateDebugInfoToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="generateDebugInfoToolStripMenuItem.Text" xml:space="preserve">
-    <value>Collect game debug info...</value>
-  </data>
-  <data name="generateDebugInfoToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>Create a zip file in the game folder containing files helpful for debugging problems with the game.</value>
-  </data>
-  <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 6</value>
-  </data>
-  <data name="fixFileAndFolderPermissionsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="fixFileAndFolderPermissionsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Fix file and folder permissions</value>
-  </data>
-  <data name="fixFileAndFolderPermissionsToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>This will attempt to fix any file or folder permission issues in the game directory.
-Make sure that no other applications are using anything inside the game directory before uisng, otherwise a PC restart might be required to be able to access some of the files again.</value>
-  </data>
-  <data name="compressGameFilesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="compressGameFilesToolStripMenuItem.Text" xml:space="preserve">
-    <value>Compress game files</value>
-  </data>
-  <data name="compressGameFilesToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>Reduce the size of the game by recompressing its asset bundles with a higher compression level.
-Generally safe but might cause issues in rare cases, especially with newer games like RG or HC. If in doubt, back up the abdata and *_Data folders.</value>
-  </data>
-  <data name="cleanUpDuplicateZipmodsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="cleanUpDuplicateZipmodsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Clean up duplicate zipmods</value>
-  </data>
-  <data name="cleanUpDuplicateZipmodsToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>Attempt to automatically clean up zipmods with the same GUIDs so that only the latest versions are left.</value>
-  </data>
-  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 6</value>
-  </data>
-  <data name="developersToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="developersToolStripMenuItem.Text" xml:space="preserve">
-    <value>Developers</value>
-  </data>
-  <data name="toolsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 20</value>
-  </data>
-  <data name="toolsToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Tools</value>
-  </data>
-  <data name="settingsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
-  </data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Settings</value>
-  </data>
-  <data name="helpToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve">
-    <value>Help</value>
-  </data>
-  <data name="menuStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="menuStrip1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 2, 0, 2</value>
-  </data>
-  <data name="menuStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1012, 24</value>
-  </data>
-  <data name="menuStrip1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="menuStrip1.Text" xml:space="preserve">
-    <value>menuStrip1</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.Name" xml:space="preserve">
-    <value>menuStrip1</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="openGameLogToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>197, 22</value>
   </data>
   <data name="openGameLogToolStripMenuItem.Text" xml:space="preserve">
-    <value>Open game log...</value>
+    <value>Open game log file(s)</value>
+  </data>
+  <data name="openGameLogToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>Find and open the most recently written log file of the current game.
+
+May open multiple log files if present, e.g. "\BepInEx\LogOutput.log" and "\output_log.txt"</value>
   </data>
   <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
     <value>194, 6</value>
@@ -291,11 +153,11 @@ Generally safe but might cause issues in rare cases, especially with newer games
   <data name="exitToolStripMenuItem.Text" xml:space="preserve">
     <value>Exit</value>
   </data>
-  <data name="openCardBrowserToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 22</value>
+  <data name="fileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 20</value>
   </data>
-  <data name="openCardBrowserToolStripMenuItem.Text" xml:space="preserve">
-    <value>Open card browser</value>
+  <data name="fileToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;File</value>
   </data>
   <data name="openFemaleCardFolderToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>202, 22</value>
@@ -317,6 +179,12 @@ Generally safe but might cause issues in rare cases, especially with newer games
   </data>
   <data name="otherToolStripMenuItem.Text" xml:space="preserve">
     <value>Open other folder...</value>
+  </data>
+  <data name="openCardBrowserToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>233, 22</value>
+  </data>
+  <data name="openCardBrowserToolStripMenuItem.Text" xml:space="preserve">
+    <value>Open card browser</value>
   </data>
   <data name="toolStripSeparator8.Size" type="System.Drawing.Size, System.Drawing">
     <value>230, 6</value>
@@ -354,6 +222,18 @@ Generally safe but might cause issues in rare cases, especially with newer games
   <data name="openLogViewerToolStripMenuItem.Text" xml:space="preserve">
     <value>Open log viewer</value>
   </data>
+  <data name="viewToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="viewToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;View</value>
+  </data>
+  <data name="startTheGameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>43, 20</value>
+  </data>
+  <data name="startTheGameToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Start</value>
+  </data>
   <data name="installDirectoryToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 22</value>
   </data>
@@ -386,6 +266,29 @@ Generally safe but might cause issues in rare cases, especially with newer games
   </data>
   <data name="kKManagerToolStripMenuItem.Text" xml:space="preserve">
     <value>KK Manager</value>
+  </data>
+  <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>98, 20</value>
+  </data>
+  <data name="openToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Open directory</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="installANewModToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="installANewModToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 20</value>
+  </data>
+  <data name="installANewModToolStripMenuItem.Text" xml:space="preserve">
+    <value>Install a new mod...</value>
+  </data>
+  <data name="installANewModToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>Attempt to install a plugin or a zipmod. 
+For plugins, patchers and especially non-zipmod mods it's recommended to follow the installation steps provided by the author instead.</value>
+  </data>
+  <data name="installANewModToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="lookForModUpdatesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>318, 22</value>
@@ -438,6 +341,56 @@ Generally safe but might cause issues in rare cases, especially with newer games
   <data name="p2PDownloaderSettingsToolStripMenuItem.ToolTipText" xml:space="preserve">
     <value>Note: FTP connections are still required even with P2P enabled.</value>
   </data>
+  <data name="updateSideloaderModpackToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 20</value>
+  </data>
+  <data name="updateSideloaderModpackToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Mod updater</value>
+  </data>
+  <data name="generateDebugInfoToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="generateDebugInfoToolStripMenuItem.Text" xml:space="preserve">
+    <value>Collect game debug info...</value>
+  </data>
+  <data name="generateDebugInfoToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>Create a zip file in the game folder containing files helpful for debugging problems with the game.</value>
+  </data>
+  <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 6</value>
+  </data>
+  <data name="fixFileAndFolderPermissionsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="fixFileAndFolderPermissionsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Fix file and folder permissions</value>
+  </data>
+  <data name="fixFileAndFolderPermissionsToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>This will attempt to fix any file or folder permission issues in the game directory.
+Make sure that no other applications are using anything inside the game directory before uisng, otherwise a PC restart might be required to be able to access some of the files again.</value>
+  </data>
+  <data name="compressGameFilesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="compressGameFilesToolStripMenuItem.Text" xml:space="preserve">
+    <value>Compress game files</value>
+  </data>
+  <data name="compressGameFilesToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>Reduce the size of the game by recompressing its asset bundles with a higher compression level.
+Generally safe but might cause issues in rare cases, especially with newer games like RG or HC. If in doubt, back up the abdata and *_Data folders.</value>
+  </data>
+  <data name="cleanUpDuplicateZipmodsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="cleanUpDuplicateZipmodsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Clean up duplicate zipmods</value>
+  </data>
+  <data name="cleanUpDuplicateZipmodsToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>Attempt to automatically clean up zipmods with the same GUIDs so that only the latest versions are left.</value>
+  </data>
+  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 6</value>
+  </data>
   <data name="openModpackToolToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>291, 22</value>
   </data>
@@ -462,6 +415,18 @@ Generally safe but might cause issues in rare cases, especially with newer games
   <data name="cleanUpDuplicateAndInvalidZipmodsToolStripMenuItem.Text" xml:space="preserve">
     <value>Clean up duplicate and invalid zipmods...</value>
   </data>
+  <data name="developersToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="developersToolStripMenuItem.Text" xml:space="preserve">
+    <value>Developers</value>
+  </data>
+  <data name="toolsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 20</value>
+  </data>
+  <data name="toolsToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Tools</value>
+  </data>
   <data name="languagesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>215, 22</value>
   </data>
@@ -481,6 +446,12 @@ Generally safe but might cause issues in rare cases, especially with newer games
     <value>Attempt to move files to the recycle bin when deleting cards/mods/plugins and when updating mods.
 If this fails for whatever reason (e.g. recycle bin is full or disabled) the files are deleted permanently.
 </value>
+  </data>
+  <data name="settingsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
+  </data>
+  <data name="settingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Settings</value>
   </data>
   <data name="checkForUpdatesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>269, 22</value>
@@ -515,6 +486,40 @@ If this fails for whatever reason (e.g. recycle bin is full or disabled) the fil
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
     <value>About</value>
   </data>
+  <data name="helpToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="helpToolStripMenuItem.Text" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="menuStrip1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="menuStrip1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 2, 0, 2</value>
+  </data>
+  <data name="menuStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1012, 24</value>
+  </data>
+  <data name="menuStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="menuStrip1.Text" xml:space="preserve">
+    <value>menuStrip1</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.Name" xml:space="preserve">
+    <value>menuStrip1</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="LanguagesToolStripComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 23</value>
   </data>
@@ -545,6 +550,12 @@ If this fails for whatever reason (e.g. recycle bin is full or disabled) the fil
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>132, 17</value>
   </metadata>
+  <data name="toolStripStatusLabelStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 17</value>
+  </data>
+  <data name="toolStripStatusLabelStatus.Text" xml:space="preserve">
+    <value>Status...</value>
+  </data>
   <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 657</value>
   </data>
@@ -568,12 +579,6 @@ If this fails for whatever reason (e.g. recycle bin is full or disabled) the fil
   </data>
   <data name="&gt;&gt;statusStrip1.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="toolStripStatusLabelStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 17</value>
-  </data>
-  <data name="toolStripStatusLabelStatus.Text" xml:space="preserve">
-    <value>Status...</value>
   </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>247, 17</value>
@@ -2466,6 +2471,18 @@ If this fails for whatever reason (e.g. recycle bin is full or disabled) the fil
   <data name="&gt;&gt;toolsToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;generateDebugInfoToolStripMenuItem.Name" xml:space="preserve">
+    <value>generateDebugInfoToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;generateDebugInfoToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator10.Name" xml:space="preserve">
+    <value>toolStripSeparator10</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;fixFileAndFolderPermissionsToolStripMenuItem.Name" xml:space="preserve">
     <value>fixFileAndFolderPermissionsToolStripMenuItem</value>
   </data>
@@ -2482,12 +2499,6 @@ If this fails for whatever reason (e.g. recycle bin is full or disabled) the fil
     <value>cleanUpDuplicateZipmodsToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;cleanUpDuplicateZipmodsToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;generateDebugInfoToolStripMenuItem.Name" xml:space="preserve">
-    <value>generateDebugInfoToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;generateDebugInfoToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator3.Name" xml:space="preserve">
@@ -2603,12 +2614,6 @@ If this fails for whatever reason (e.g. recycle bin is full or disabled) the fil
   </data>
   <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator10.Name" xml:space="preserve">
-    <value>toolStripSeparator10</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MainWindow</value>


### PR DESCRIPTION
Refactored and improved log file detection logic for both the "open log" and "gather debug info" menu items.
- Log files in AppData are now detected.
- The "Open log file" menu item can now open multiple files at the same time if need be.